### PR TITLE
Support Launching from Compose Activity

### DIFF
--- a/oauth2/src/androidTest/java/com/ebay/api/client/auth/oauth2/AuthorizationLinkTest.kt
+++ b/oauth2/src/androidTest/java/com/ebay/api/client/auth/oauth2/AuthorizationLinkTest.kt
@@ -91,7 +91,7 @@ class AuthorizationLinkTest {
             hasData(Uri.parse("ebay.oauth2://authorize?client_id=clientId&redirect_uri=https%3A%2F%2Ftest.redirect.uri.com%2Fauthdeeplink&response_type=code&scope=scope&prompt=login"))
         )
 
-        val context = InstrumentationRegistry.getInstrumentation().context
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
         val authorizationLink = AuthorizationLink(
             context,
             ApiEnvironment.PRODUCTION,

--- a/oauth2/src/main/java/com/ebay/api/client/auth/oauth2/AuthorizationLink.kt
+++ b/oauth2/src/main/java/com/ebay/api/client/auth/oauth2/AuthorizationLink.kt
@@ -15,6 +15,7 @@
 
 package com.ebay.api.client.auth.oauth2
 
+import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
@@ -128,27 +129,30 @@ class AuthorizationLink {
 
 
     private fun launchOauthChromeTabs(): Boolean {
-        val intent = CustomTabsIntent.Builder().build()
+        val cctIntent = CustomTabsIntent.Builder().build()
+        sanitizeIntent(cctIntent.intent)
         val packageName = customTabsHelper.getPackageNameToUse()
-        packageName.let {
-            intent.intent.setPackage(packageName)
-            intent.launchUrl(context, buildWebUri())
+        packageName?.let {
+            cctIntent.intent.setPackage(packageName)
+            cctIntent.launchUrl(context, buildWebUri())
             return true
         }
         return false
     }
 
     private fun launchOauthBrowser(): Boolean {
-        context.startActivity(Intent(Intent.ACTION_VIEW, buildWebUri()))
+        val intent = Intent(Intent.ACTION_VIEW, buildWebUri())
+        context.startActivity(sanitizeIntent(intent))
         return true
     }
 
+    private fun sanitizeIntent(intent: Intent): Intent =
+        intent.apply { if (context !is Activity) addFlags(Intent.FLAG_ACTIVITY_NEW_TASK) }
 
     private fun launchOauthNative(): Boolean {
         val intent = Intent(Intent.ACTION_VIEW, buildUserConsentLink(userConsentDeepLink))
-
         return if (deepLinkHelper.verifyEbayDeepLink(intent)) {
-            context.startActivity(intent)
+            context.startActivity(sanitizeIntent(intent))
             true
         } else
             false

--- a/oauth2/src/main/java/com/ebay/api/client/auth/oauth2/OAuthService.kt
+++ b/oauth2/src/main/java/com/ebay/api/client/auth/oauth2/OAuthService.kt
@@ -17,7 +17,9 @@ package com.ebay.api.client.auth.oauth2
 
 import android.content.Intent
 import android.os.Bundle
-import androidx.appcompat.app.AppCompatActivity
+import android.widget.Toast
+import androidx.core.app.ComponentActivity
+import androidx.fragment.app.FragmentActivity
 import com.ebay.api.client.auth.oauth2.model.*
 import com.ebay.api.client.auth.oauth2.ui.ErrorDialogFragment
 import com.ebay.api.client.auth.oauth2.ui.OAuthActivity
@@ -26,7 +28,7 @@ import com.ebay.api.client.auth.oauth2.ui.OAuthActivity
  * Main class to perform eBay Oauth 2.0 for native apps
  */
 class OAuthService(
-    private val activity: AppCompatActivity,
+    private val activity: ComponentActivity,
     private val requestCode: Int = OAUTH_REQUEST_CODE
 ) {
 
@@ -125,14 +127,20 @@ class OAuthService(
 
 
     private fun showErrorDialog(message: String) {
-        var fragment = ErrorDialogFragment().apply {
-            arguments = Bundle().apply {
-                putString(ErrorDialogFragment.KEY_TITLE, activity?.getString(R.string.oauth_error))
-                putString(ErrorDialogFragment.KEY_MESSAGE, message)
+        when (activity) {
+            is FragmentActivity -> {
+                val fragment = ErrorDialogFragment().apply {
+                    arguments = Bundle().apply {
+                        putString(ErrorDialogFragment.KEY_TITLE, activity?.getString(R.string.oauth_error))
+                        putString(ErrorDialogFragment.KEY_MESSAGE, message)
+                    }
+                }
+                fragment.show(activity.supportFragmentManager, ErrorDialogFragment.TAG)
+            }
+            else -> {
+                Toast.makeText(activity, message, Toast.LENGTH_SHORT).show()
             }
         }
-
-        fragment.show(activity.supportFragmentManager, ErrorDialogFragment.TAG)
     }
 
     companion object {


### PR DESCRIPTION
- Removed dependency on AppCompatActivity in OAuthService.kt
- Added an instance check in showErrorDialog so it still supports the ErrorDialogFragment if the Activity has Fragments. Otherwise it will use a toast. This allows this to be used from a Compose Activity.
- Instrumentation tests were not running due to missing flags on the intent when launching from the application context.