### PR TITLE
redirect uri should be RuName, not a url.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -25,7 +25,7 @@ This library is distributed via maven central repository. To use this library, i
 
 ```
 dependencies {
-    compile 'com.ebay.auth:ebay-oauth-android-client:1.0.1'
+    implementation 'com.ebay.auth:ebay-oauth-android-client:1.0.1'
 }
 ```
 
@@ -53,7 +53,7 @@ To receive Authorization code, client app must override `OauthRedirectActivity` 
 
 ```
         <activity
-            android:name=".oauth2.ui.OAuthRedirectActivity"
+            android:name="com.ebay.api.client.auth.oauth2.ui.OAuthRedirectActivity"
             android:exported="true"
             tools:node="replace">
             <intent-filter>
@@ -133,7 +133,7 @@ To get the sample working, there are two steps:
 2. Open AndroidManifest.xml and edit the redirect_uri with registered redirect_uri from developer portal
 ```
         <activity
-            android:name=".oauth2.ui.OAuthRedirectActivity"
+            android:name="com.ebay.api.client.auth.oauth2.ui.OAuthRedirectActivity"
             android:exported="true"
             tools:node="replace">
             <intent-filter>

--- a/Readme.md
+++ b/Readme.md
@@ -33,7 +33,7 @@ dependencies {
 # Application Setup
 Before performing OAuth, the library should be initialized with details about your application from eBay developer portal. The library uses 
 - Client ID. For details see [Getting your OAuth credentials](https://developer.ebay.com/api-docs/static/oauth-credentials.html)
-- Redirect Uri. for details see [Getting your Redirect_Uri](https://developer.ebay.com/api-docs/static/oauth-redirect-uri.html)
+- Redirect Uri (RuName). for details see [Getting your Redirect_Uri](https://developer.ebay.com/api-docs/static/oauth-redirect-uri.html)
 - Url encoded list of scopes. for details see [Specifying OAuth scopes](https://developer.ebay.com/api-docs/static/oauth-scopes.html)
 
 Use these details in `ApiSessionConfiguration.initialize()` as shown below:
@@ -43,7 +43,7 @@ Use these details in `ApiSessionConfiguration.initialize()` as shown below:
                 apiEnvironment = ApiEnvironment.PRODUCTION,
                 apiConfiguration = ApiConfiguration(
                     <Client ID>,
-                    <Redirect Uri>,
+                    <Redirect Uri / RuName>,
                     <space separated scopes>
                 )
             )

--- a/oauth2/src/main/java/com/ebay/api/client/auth/oauth2/AuthorizationLink.kt
+++ b/oauth2/src/main/java/com/ebay/api/client/auth/oauth2/AuthorizationLink.kt
@@ -111,14 +111,6 @@ class AuthorizationLink {
         if (grantType != GrantType.AUTHORIZATION_CODE)
             return unSupportedGrantType
 
-        // Only allow https redirect uri
-        if (!redirectUri.startsWith("https"))
-            return invalidRedirectUri
-
-        // verify redirect_uri deep link
-        if (!deepLinkHelper.verifyDeepLinkInCurrentApp(redirectUri))
-            return String.format(missingRedirectUriDeepLink, redirectUri)
-
         // verify environment when native deep link
         if (environment == ApiEnvironment.SANDBOX &&
             deepLinkHelper.verifyEbayDeepLink(Intent(Intent.ACTION_VIEW, Uri.parse(userConsentDeepLink))))

--- a/oauth2/src/main/java/com/ebay/api/client/auth/oauth2/model/ApiSessionConfiguration.kt
+++ b/oauth2/src/main/java/com/ebay/api/client/auth/oauth2/model/ApiSessionConfiguration.kt
@@ -28,11 +28,11 @@ class ApiSessionConfiguration private constructor() {
         private val instance: ApiSessionConfiguration = ApiSessionConfiguration()
 
         @Synchronized
-        fun getInstance(): ApiSessionConfiguration {
+        @JvmStatic fun getInstance(): ApiSessionConfiguration {
             return instance
         }
 
-        fun initialize(apiEnvironment: ApiEnvironment, apiConfiguration: ApiConfiguration) : ApiSessionConfiguration {
+        @JvmStatic fun initialize(apiEnvironment: ApiEnvironment, apiConfiguration: ApiConfiguration) : ApiSessionConfiguration {
             instance.apiEnvironment = apiEnvironment
             instance.apiConfiguration = apiConfiguration
             return instance

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -18,7 +18,7 @@
         </activity>
 
         <activity
-            android:name=".oauth2.ui.OAuthRedirectActivity"
+            android:name="com.ebay.api.client.auth.oauth2.ui.OAuthRedirectActivity"
             android:exported="true"
             tools:node="replace">
 <!--            <intent-filter>-->

--- a/sample/src/main/java/com/ebay/api/client/auth/MainActivity.kt
+++ b/sample/src/main/java/com/ebay/api/client/auth/MainActivity.kt
@@ -38,7 +38,7 @@ class MainActivity : AppCompatActivity() {
                 apiEnvironment = ApiEnvironment.PRODUCTION,
                 apiConfiguration = ApiConfiguration(
                     "<app id>",
-                    "<redirect uri>",
+                    "<redirect uri / RuName>",
                     "scope_1 " + "scope_2"
                 )
             )


### PR DESCRIPTION
In AuthorizationLink.kt some unfulfillable checks leave the user no choice but to enter invalid information.
For redirect uri the RuName should be enterned (eg. Davy_Developer-DavyDeve-DavysT-euiukxwt) not https://my-accept-url.
You can get more information here (https://developer.ebay.com/api-docs/static/oauth-consent-request.html):
![image](https://user-images.githubusercontent.com/13346316/217808119-42c006b5-87b0-48e0-8555-459fee8f47bb.png)
You checks for uri begin with https:// is unfulfillable. As well as the check if redirect uri equals the informations entered in AndroidManifest.xml.

Later on when I exchange the authorization code for a User access token I enter redirect uri as RuName as well (https://developer.ebay.com/api-docs/static/oauth-auth-code-grant-request.html):
![image](https://user-images.githubusercontent.com/13346316/217809036-f5fc20ca-f3a9-499c-9e4c-c0827bdaf33e.png)
